### PR TITLE
chore(migration): save name and backfill all null values

### DIFF
--- a/db/migrations/20200302163817_backfill_movies_name.js
+++ b/db/migrations/20200302163817_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.raw('UPDATE movies SET name = title');
+};
+
+exports.down = (Knex, Promise) => {
+  return Promise.resolve();
+};

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,6 +3,7 @@
 const Movie = require('../../../models/movie');
 
 exports.create = async (payload) => {
+  payload.name = payload.title;
   const movie = await new Movie().save(payload);
 
   return new Movie({ id: movie.id }).fetch();


### PR DESCRIPTION
## Why

Prepares `name` to replace `title` column in `movies` table

## Details

My implementation assumes that the user behavior remains the same and our endpoint is still being passed the `title` key